### PR TITLE
Add data import and persistent events

### DIFF
--- a/public_html/sitepro/a1976de6efde00902520b312949e4a0a.php
+++ b/public_html/sitepro/a1976de6efde00902520b312949e4a0a.php
@@ -89,6 +89,8 @@
       cost = Array(12).fill(0);
       buildings = Array(12).fill(0);
       hours = Array(12).fill(0);
+      calendarInstance.removeAllEvents();
+      saveEvents();
       localStorage.setItem('revenue', JSON.stringify(revenue));
       localStorage.setItem('cost', JSON.stringify(cost));
       localStorage.setItem('buildings', JSON.stringify(buildings));
@@ -174,6 +176,7 @@
       <button onclick="showSection('employees')" class="w-full text-left px-4 py-2 hover:bg-slate-700"><i class="fa-solid fa-user-gear"></i> Zaposlenici</button>
       <button onclick="showSection('calendar')" class="w-full text-left px-4 py-2 hover:bg-slate-700"><i class="fa-solid fa-calendar-days"></i> Kalendar</button>
       <button onclick="showSection('equipment')" class="w-full text-left px-4 py-2 hover:bg-slate-700"><i class="fa-solid fa-screwdriver-wrench"></i> Oprema</button>
+      <button onclick="showSection('reports')" class="w-full text-left px-4 py-2 hover:bg-slate-700"><i class="fa-solid fa-chart-pie"></i> Izvještaji</button>
     </nav><div class="p-4">
       <button onclick="toggleDark()" class="w-full bg-slate-700 hover:bg-slate-600 px-3 py-2 rounded"><i class="fa-solid fa-moon"></i> Tamni mod</button>
     </div>
@@ -263,6 +266,16 @@
         <input oninput="filterTable('equipmentTable', this.value)" type="text" placeholder="Brza pretraga..." class="border px-2 py-1 rounded w-full mb-2"><div class="overflow-x-auto">
           <table id="equipmentTable" class="min-w-full text-sm bg-white dark:bg-slate-800 rounded shadow"><thead><tr class="bg-gray-200 dark:bg-slate-700"><th class="px-2 py-1">Naziv</th><th class="px-2 py-1">Status</th><th class="px-2 py-1">Akcija</th>
               </tr></thead><tbody></tbody></table></div>
+      </section><!-- Reports --><section id="reportsSection" class="hidden space-y-4">
+        <h2 class="text-xl font-semibold">Izvještaji</h2>
+        <div class="bg-white dark:bg-slate-800 p-4 rounded shadow">
+          <p>Ukupan prihod: <span id="repRevenue">0</span> EUR</p>
+          <p>Ukupan trošak: <span id="repCost">0</span> EUR</p>
+          <p>Neto dobit: <span id="repNet">0</span> EUR</p>
+          <button onclick="exportAllData()" class="bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded mt-2">Preuzmi JSON</button>
+          <input id="importFile" type="file" accept="application/json" class="hidden" onchange="importAllData(event)">
+          <button onclick="document.getElementById('importFile').click()" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded mt-2 ml-2">Učitaj JSON</button>
+        </div>
       </section></div>
   </main><!-- Overlay & Modals --><div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden"></div>
 
@@ -325,13 +338,18 @@
 
     // Navigation
     function showSection(section) {
-      ['overview','finance','clients','employees','calendar','equipment'].forEach(s=>{
+      ['overview','finance','clients','employees','calendar','equipment','reports'].forEach(s=>{
         document.getElementById(s+'Section').classList.toggle('hidden', s!==section);
       });
       document.getElementById('sectionTitle').innerText = {
-        overview:'Pregled', finance:'Financije', clients:'Klijenti', employees:'Zaposlenici', calendar:'Kalendar', equipment:'Oprema'
+        overview:'Pregled', finance:'Financije', clients:'Klijenti', employees:'Zaposlenici', calendar:'Kalendar', equipment:'Oprema', reports:'Izvještaji'
       }[section];
       if(section==='finance') { renderFinanceTable(); updateFinance(); }
+      if(section==='reports') {
+        document.getElementById('repRevenue').innerText = revenue.reduce((a,b)=>a+b,0);
+        document.getElementById('repCost').innerText = cost.reduce((a,b)=>a+b,0);
+        document.getElementById('repNet').innerText = revenue.reduce((a,b,i)=>a+(b-cost[i]),0);
+      }
       updateKPIs();
     }
 
@@ -349,11 +367,55 @@
     }
     function exportCurrentSection() {
       const sec = document.getElementById('sectionTitle').innerText.toLowerCase();
-      if(sec==='financije' || sec==='financije' ) exportTableToCSV('finance.csv','financeTable');
+      if(sec==='financije' || sec==='finance') exportTableToCSV('finance.csv','financeTable');
       else if(sec==='klijenti') exportTableToCSV('clients.csv','clientsTable');
       else if(sec==='zaposlenici') exportTableToCSV('employees.csv','employeesTable');
       else if(sec==='oprema') exportTableToCSV('equipment.csv','equipmentTable');
       else alert('Nema podataka za izvoz u ovoj sekciji.');
+    }
+
+    function importAllData(e){
+      const file = e.target.files[0];
+      if(!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const d = JSON.parse(reader.result);
+          if(Array.isArray(d.revenue) && d.revenue.length===12) revenue = d.revenue;
+          if(Array.isArray(d.cost) && d.cost.length===12) cost = d.cost;
+          if(Array.isArray(d.buildings) && d.buildings.length===12) buildings = d.buildings;
+          if(Array.isArray(d.hours) && d.hours.length===12) hours = d.hours;
+          if(Array.isArray(d.clients)) clients = d.clients;
+          if(Array.isArray(d.employees)) employees = d.employees;
+          if(Array.isArray(d.equipment)) equipment = d.equipment;
+          calendarInstance.removeAllEvents();
+          if(Array.isArray(d.events)) d.events.forEach(ev=>calendarInstance.addEvent(ev));
+          saveEvents();
+          localStorage.setItem('revenue', JSON.stringify(revenue));
+          localStorage.setItem('cost', JSON.stringify(cost));
+          localStorage.setItem('buildings', JSON.stringify(buildings));
+          localStorage.setItem('hours', JSON.stringify(hours));
+          localStorage.setItem('clients', JSON.stringify(clients));
+          localStorage.setItem('employees', JSON.stringify(employees));
+          localStorage.setItem('equipment', JSON.stringify(equipment));
+          renderClients(); renderEmployees(); renderEquipment();
+          renderFinanceTable(); updateFinance(); updateKPIs();
+          alert('Podaci učitani.');
+        } catch(err){
+          alert('Neispravan JSON');
+        }
+      };
+      reader.readAsText(file);
+    }
+
+    function exportAllData() {
+      const events = calendarInstance.getEvents().map(e=>({title:e.title,start:e.startStr}));
+      const data = {revenue,cost,buildings,hours,clients,employees,equipment,events};
+      const blob = new Blob([JSON.stringify(data,null,2)], {type:'application/json'});
+      const link = document.createElement('a');
+      link.download = 'dashboard_data.json';
+      link.href = URL.createObjectURL(blob);
+      link.click();
     }
 
     // CRUD render
@@ -471,9 +533,17 @@
         height:600,
         selectable:true,
         headerToolbar:{left:'title',center:'prev,next today',right:'dayGridMonth,timeGridWeek'},
-        dateClick:info=>{const t=prompt('Naziv zadatka:');if(t){calendarInstance.addEvent({title:t,start:info.dateStr});updateKPIs();}}
+        dateClick:info=>{const t=prompt('Naziv zadatka:');if(t){calendarInstance.addEvent({title:t,start:info.dateStr});saveEvents();updateKPIs();}},
+        eventClick:info=>{if(confirm('Obrisati zadatak?')){info.event.remove();saveEvents();updateKPIs();}}
       });
       calendarInstance.render();
+      const stored = JSON.parse(localStorage.getItem('events')||'[]');
+      stored.forEach(ev=>calendarInstance.addEvent(ev));
+    }
+
+    function saveEvents(){
+      const evs = calendarInstance.getEvents().map(e=>({title:e.title,start:e.startStr}));
+      localStorage.setItem('events', JSON.stringify(evs));
     }
 
     // KPIs

--- a/public_html/sitepro/a1976de6efde00902520b312949e4a0a.php
+++ b/public_html/sitepro/a1976de6efde00902520b312949e4a0a.php
@@ -68,93 +68,10 @@
 <div data-replaced-tag="html" lang="hr">
 <div data-replaced-tag="head">
   <title>Gewerbe Dashboard – Gebäudereinigung &amp; Hausmeisterservice</title><!-- Tailwind CSS --><script src="https://cdn.tailwindcss.com">
-    // Load initial data
-    function loadInitialData() {
-      if (!confirm('Učitati inicijalne testne podatke? Ovo će prebrisati postojeće.')) return;
-      revenue = initRevenue.slice();
-      cost = initCost.slice();
-      buildings = initBuildings.slice();
-      hours = initHours.slice();
-      localStorage.setItem('revenue', JSON.stringify(revenue));
-      localStorage.setItem('cost', JSON.stringify(cost));
-      localStorage.setItem('buildings', JSON.stringify(buildings));
-      localStorage.setItem('hours', JSON.stringify(hours));
-      renderFinanceTable(); updateFinance(); updateKPIs();
-    }
-
-    // Reset all data to zero
-    function resetData() {
-      if (!confirm('Resetirati sve podatke na nulu?')) return;
-      revenue = Array(12).fill(0);
-      cost = Array(12).fill(0);
-      buildings = Array(12).fill(0);
-      hours = Array(12).fill(0);
-      calendarInstance.removeAllEvents();
-      saveEvents();
-      localStorage.setItem('revenue', JSON.stringify(revenue));
-      localStorage.setItem('cost', JSON.stringify(cost));
-      localStorage.setItem('buildings', JSON.stringify(buildings));
-      localStorage.setItem('hours', JSON.stringify(hours));
-      renderFinanceTable(); updateFinance(); updateKPIs();
-    }
 
   </script><!-- FontAwesome Icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"><!-- Chart.js --><script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js">
-    // Load initial data
-    function loadInitialData() {
-      if (!confirm('Učitati inicijalne testne podatke? Ovo će prebrisati postojeće.')) return;
-      revenue = initRevenue.slice();
-      cost = initCost.slice();
-      buildings = initBuildings.slice();
-      hours = initHours.slice();
-      localStorage.setItem('revenue', JSON.stringify(revenue));
-      localStorage.setItem('cost', JSON.stringify(cost));
-      localStorage.setItem('buildings', JSON.stringify(buildings));
-      localStorage.setItem('hours', JSON.stringify(hours));
-      renderFinanceTable(); updateFinance(); updateKPIs();
-    }
-
-    // Reset all data to zero
-    function resetData() {
-      if (!confirm('Resetirati sve podatke na nulu?')) return;
-      revenue = Array(12).fill(0);
-      cost = Array(12).fill(0);
-      buildings = Array(12).fill(0);
-      hours = Array(12).fill(0);
-      localStorage.setItem('revenue', JSON.stringify(revenue));
-      localStorage.setItem('cost', JSON.stringify(cost));
-      localStorage.setItem('buildings', JSON.stringify(buildings));
-      localStorage.setItem('hours', JSON.stringify(hours));
-      renderFinanceTable(); updateFinance(); updateKPIs();
-    }
 
   </script><!-- FullCalendar --><link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet"><script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js">
-    // Load initial data
-    function loadInitialData() {
-      if (!confirm('Učitati inicijalne testne podatke? Ovo će prebrisati postojeće.')) return;
-      revenue = initRevenue.slice();
-      cost = initCost.slice();
-      buildings = initBuildings.slice();
-      hours = initHours.slice();
-      localStorage.setItem('revenue', JSON.stringify(revenue));
-      localStorage.setItem('cost', JSON.stringify(cost));
-      localStorage.setItem('buildings', JSON.stringify(buildings));
-      localStorage.setItem('hours', JSON.stringify(hours));
-      renderFinanceTable(); updateFinance(); updateKPIs();
-    }
-
-    // Reset all data to zero
-    function resetData() {
-      if (!confirm('Resetirati sve podatke na nulu?')) return;
-      revenue = Array(12).fill(0);
-      cost = Array(12).fill(0);
-      buildings = Array(12).fill(0);
-      hours = Array(12).fill(0);
-      localStorage.setItem('revenue', JSON.stringify(revenue));
-      localStorage.setItem('cost', JSON.stringify(cost));
-      localStorage.setItem('buildings', JSON.stringify(buildings));
-      localStorage.setItem('hours', JSON.stringify(hours));
-      renderFinanceTable(); updateFinance(); updateKPIs();
-    }
 
   </script><style>
     /* Scrollbar */


### PR DESCRIPTION
## Summary
- allow importing JSON data in Reports section
- persist calendar events in localStorage
- enable event deletion and saving
- fix export condition for finance section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684db815f8288322ab38d45517024fff